### PR TITLE
Fix: Resolve Unicode charmap error in stdout streaming

### DIFF
--- a/app.py
+++ b/app.py
@@ -239,11 +239,9 @@ class StreamingStdout:
         self.original_stdout = original_stdout
         self.output_queue = output_queue
         self.buffer = ""
+        self.encoding = 'utf-8'
 
     def write(self, text):
-        if isinstance(text, bytes):
-            text = text.decode('utf-8', errors='replace')
-
         self.original_stdout.write(text)
         self.original_stdout.flush()
 


### PR DESCRIPTION
The application would raise a `UnicodeEncodeError` ('charmap' codec can't encode character) when the `caption_openai.py` script printed a Unicode character.

This was caused by redirecting `sys.stdout` to a custom `StreamingStdout` object in `app.py` that was missing the `encoding` attribute. Python's `print()` function would then fall back to a default, non-Unicode-friendly system encoding.

The fix involves two changes to the `StreamingStdout` class:
1.  Added `self.encoding = 'utf-8'` to the `__init__` method to explicitly declare the stream's encoding.
2.  Removed a now-redundant and incorrect block that attempted to decode bytes in the `write` method. This was related to a previous attempt at a fix and is no longer needed.